### PR TITLE
feat(publishing): remove unnecessary files from npm package & reduce …

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,23 +31,22 @@
     "start": "gulp",
     "prepublish": "gulp"
   },
-  "peerDependencies": {
-    "@angular/common": "^2.2.4",
-    "@angular/compiler": "^2.2.4",
-    "@angular/core": "^2.2.4",
-    "@angular/http": "^2.2.4",
-    "@angular/platform-browser": "^2.2.4",
-    "@angular/router": "^3.2.4",
-    "core-js": "^2.4.1",
-    "rxjs": "^5.0.0-beta.12",
-    "zone.js": "^0.6.17"
+  "dependencies": {
+    "@angular/common": "2.0.0",
+    "@angular/core": "2.0.0",
+    "@angular/http": "2.0.0"
   },
   "devDependencies": {
+    "@angular/compiler": "2.0.0",
+    "@angular/platform-browser": "2.0.0",
+    "@angular/router": "3.0.0",
     "angular2-template-loader": "^0.5.0",
     "autoprefixer": "^6.4.0",
+    "core-js": "2.4.1",
     "cssnano": "^3.7.4",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
+    "gulp-file": "^0.3.0",
     "gulp-inline-ng2-template": "^3.0.0",
     "gulp-postcss": "^6.1.1",
     "gulp-sass": "^2.3.2",
@@ -59,7 +58,9 @@
     "merge2": "^1.0.2",
     "postcss-scss": "^0.3.0",
     "postcss-strip-inline-comments": "^0.1.5",
+    "rxjs": "5.0.0-beta.12",
     "tslint": "^3.15.1",
-    "typings": "^1.3.3"
+    "typings": "^1.3.3",
+    "zone.js": "0.6.21"
   }
 }


### PR DESCRIPTION
…library peer dependencies

First, great work on the library: it is very useful and very well written. Congrats! 👍 

I'm planning on contributing to this project in the future, by adding more tests, travis integration, and more social media buttons, respectively. 

But currently, the project cannot just be forked, developed on locally, and pushed back, without a few changes to fix blocker compilation issues (due to the way dependencies are declared project's `package.json`). 

This first PR (of many to come i hope) aims to fix some issues with the packaging/publishing of the library.

1 -  The library declares too much `peerDependencies` from Angular. Only the following node modules are directly used in the library source code:
- `@angular/core`
- `@angular/http`
- and `@angular/common`
So the library should only depends on those.  This is how it is done in many ng libraries, like the  popular [ng-bootstrap](https://github.com/ng-bootstrap/ng-bootstrap) project

The other modules like `@angular/router`, `@angular/compiler`, `@angular/platform-browser`, `core-js.js`, `rxjs` are more like `devDependencies` needed to compile the library. 

2 - Too strict `peerDependencies` versions. Your library requires angular 2.2.4 and above, whereas  dependencies on @angular **^2.0.0** would be more than enough and avoid users the need to be using at least this exact version too.

3 - Currently the whole project structure is published to `npm` (demo files, tests folder, editors settings folders, ...) whereas only the content of generated `dist` folder (i.e compiled ts files) is needed by final users of the library ( in addition to `package.json` and optional `LICENSE`, `README.md`, and `CHANGELOG.md` files  to avoid warnings during `npm install`).`

The PR addresses theses issues, by updating the `package.json` and by adding a main gulp task :

`gulp publish`

It compiles the project as before, builds and copies a `package.json` file (with relevant fields only) to `dist` folder, along with `README.md`, `CHANGELOG.md`, `LICENSE` file) and publish the folder to NPM Registry.


I'm opened to your feedback,


Cheers!


