### PR TITLE
Fix for window being undefined on Node.

### DIFF
--- a/src/service/window.service.ts
+++ b/src/service/window.service.ts
@@ -11,5 +11,5 @@ export class WindowService {
 
 function _window() : any {
   // return the global native browser window object
-  return window || undefined;
+  return typeof window != 'undefined' ? window : undefined;
 }


### PR DESCRIPTION
This is related to the same issue #6 where if you just try use window which is undeclared on Node then Angular Universal crashes.
A simple check makes sure window is not undefined, before using it.