### PR TITLE
chore(demo): update demo app to use built 'ng2-sharebuttons' package …

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,8 @@
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update",
-    "e2e": "protractor"
+    "e2e": "protractor",
+    "postinstall": "npm link ng2-sharebuttons"
   },
   "private": true,
   "dependencies": {
@@ -20,9 +21,10 @@
     "@angular/platform-browser": "^2.3.1",
     "@angular/platform-browser-dynamic": "^2.3.1",
     "@angular/router": "^3.3.1",
-    "core-js": "^2.4.1",
     "animate.css": "^3.5.2",
+    "core-js": "^2.4.1",
     "font-awesome": "*",
+    "ng2-sharebuttons": "^1.1.5",
     "normalize.css": "*",
     "prismjs": "^1.5.1",
     "rxjs": "^5.0.1",

--- a/demo/src/app/header/header.component.ts
+++ b/demo/src/app/header/header.component.ts
@@ -7,15 +7,15 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HeaderComponent implements OnInit {
 
-  ngShareButtonLogo = prefixRepo('../../assets/img/logo.svg');
-  fbLogo = prefixRepo('../../assets/img/share/facebook.svg');
-  twttLogo = prefixRepo('../../assets/img/share/twitter.svg');
-  pintLogo = prefixRepo('../../assets/img/share/pinterest.svg');
-  stumbleLogo = prefixRepo('../../assets/img/share/stumbleupon.svg');
-  googleLogo = prefixRepo('../../assets/img/share/google-plus.svg');
-  tumblrLogo = prefixRepo('../../assets/img/share/tumblr.svg');
-  redditLogo = prefixRepo('../../assets/img/share/reddit.svg');
-  inLogo = prefixRepo('../../assets/img/share/linkedin.svg');
+  ngShareButtonLogo = '../../assets/img/logo.svg';
+  fbLogo = '../../assets/img/share/facebook.svg';
+  twttLogo = '../../assets/img/share/twitter.svg';
+  pintLogo = '../../assets/img/share/pinterest.svg';
+  stumbleLogo = '../../assets/img/share/stumbleupon.svg';
+  googleLogo = '../../assets/img/share/google-plus.svg';
+  tumblrLogo = '../../assets/img/share/tumblr.svg';
+  redditLogo = '../../assets/img/share/reddit.svg';
+  inLogo = '../../assets/img/share/linkedin.svg';
 
   constructor() { }
 
@@ -23,6 +23,3 @@ export class HeaderComponent implements OnInit {
   }
 
 }
-var prefixRepo = (path) => {
-  return  'ng2-sharebuttons' + path;
-};

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Angular Share buttons</title>
-  <base href="/ng2-sharebuttons/">
+  <base href="/">
   <!--ng2-sharebuttons/-->
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
@@ -32,10 +32,10 @@
 
   <script>
     (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
     ga('create', 'UA-81405917-3', 'auto');
     ga('send', 'pageview');


### PR DESCRIPTION
…from `dist/` folder

- add a gulp task `link` , to create a symlink from 'ng2-sharebuttons' package to `dist/` folder
- add a dependency to 'ng2-sharebuttons' in the demo project
- add a `postinstall` hook to `demo/package.json` to automatically use the 'linked' version instead of the one from NPM
- fix `baseUrl` in `demo/src/index.html`
- fix logos links in HeaderComponent


With theses changes:
- we no longer have to copy library files to demo project( ++maintainability)  
- we can  spot issues with the packaged library earlier (without having to publish it to NPM first)
- we use the library as final users do, so we can spot any error they might have, earlier


You will have to run `gulp link`  (only once, from library project) and then `npm install` (from demo project) to set everything up.


Cheers!


