### PR TITLE
chore(ShareButtonComponent): refactor share-button.component

### DIFF
--- a/src/components/share-button/share-button.component.html
+++ b/src/components/share-button/share-button.component.html
@@ -1,0 +1,2 @@
+<button (click)='share()' [innerHTML]="button.template" [ngClass]="button.classes"></button>
+<span *ngIf="count && shareCount" class="sb-button-count">{{ shareCount | nFormatter: 1 }}</span>

--- a/src/components/share-button/share-button.component.spec.ts
+++ b/src/components/share-button/share-button.component.spec.ts
@@ -10,12 +10,18 @@ import { ShareButtonsModule } from '../../share-buttons.module';
 import { ShareButtonComponent } from './share-button.component';
 import { ShareButtonsService } from '../../service/share-buttons.service';
 import { WindowService } from './../../service/window.service';
-import { ShareButton, ShareArgs, ShareProvider, Helper } from '../../helpers';
+import { ShareButton, ShareArgs, ShareProvider, Helper, NFormatterPipe } from '../../helpers';
 import { TestHelpers } from '../../test-helpers';
 
 
 const createTestComponent = (html: string, detectChanges?: boolean) =>
   TestHelpers.createGenericTestComponent(html, detectChanges, TestComponent) as ComponentFixture<TestComponent>;
+
+const getShareButtonComponent = (fixture: ComponentFixture<TestComponent>): ShareButtonComponent =>
+  fixture.debugElement.query(By.css('share-button')).componentInstance as ShareButtonComponent;
+
+const getShareButtonDebugElm = (fixture: ComponentFixture<TestComponent>): DebugElement =>
+  fixture.debugElement.query(By.css('share-button'));
 
 const sArgs = new ShareArgs('http://www.mysite.com', 'my title', 'my description', 'https://my/image.png', 'tag1,tag2');
 const sBtn = new ShareButton(ShareProvider.LINKEDIN, '<i class="fa fa-linkedin"></i>', 'linkedin');
@@ -29,10 +35,9 @@ describe('ShareButtonComponent (as a stand-alone component)', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [HttpModule, JsonpModule],
-      declarations: [ShareButtonComponent],
-      providers: [ShareButtonsService, Renderer,
-        { provide: WindowService, useClass: TestHelpers.MockWindowService },
-        { provide: ElementRef, useClass: TestHelpers.MockElementRef }]
+      declarations: [ShareButtonComponent, NFormatterPipe],
+      providers: [ShareButtonsService,
+        { provide: WindowService, useClass: TestHelpers.MockWindowService }]
     })
       .compileComponents();
   }));
@@ -59,166 +64,21 @@ describe('ShareButtonComponent (as a stand-alone component)', () => {
     expect(shareButton).toBeTruthy();
   });
 
-  it('should bind to given inputs', () => {
 
-    // set mandatory inputs
-    component.button = sBtn;
-
-    // optional inputs
-    component.url = sArgs.url;
-    component.title = sArgs.title;
-    component.description = sArgs.description;
-    component.image = sArgs.image;
-    component.tags = sArgs.tags;
-
-    fixture.detectChanges(); // trigger data binding
-
-    expect(shareButton.nativeElement.innerHTML).toEqual(sBtn.template);
-    expect(shareButton.nativeElement.className).toEqual(sBtn.classes);
-
-  });
-
-  it('should use "window.location.href" when no url is provided', () => {
-    // set mandatory inputs
-    component.button = sBtn;
-
-    // optional inputs
-    component.url = undefined; // no url
-    fixture.detectChanges(); // trigger data binding
-
-    expect(component.url).toEqual(encodeURIComponent(TestHelpers.windowUrl));
-
-  });
-
-  it('should use "window.location.href" when provided url is invalid', () => {
-    // set mandatory inputs
-    component.button = sBtn;
-
-    // optional inputs
-    component.url = 'invalid://www.mysite.com';
-    fixture.detectChanges(); // trigger data binding
-
-    expect(component.url).toEqual(encodeURIComponent(TestHelpers.windowUrl));
-
-  });
-
-  it('should call share() when the button is clicked and emit "popUpClosed" event',
-    inject([WindowService, ShareButtonsService], (windowService: WindowService, sbService: ShareButtonsService) => {
-
-      // set mandatory inputs
-      component.button = sBtn;
-
-      // optional inputs
-      component.url = sArgs.url;
-      component.title = sArgs.title;
-      component.description = sArgs.description;
-      component.image = sArgs.image;
-      component.tags = sArgs.tags;
-
-      let emittedProvider: ShareProvider;
-      component.popUpClosed.subscribe((provider: ShareProvider) => {
-        emittedProvider = provider;
-      });
-
-      fixture.detectChanges(); // trigger data binding
-
-      const shareUrl = Helper.shareFactory(sBtn.provider, sArgs);
-      const shareSpy = spyOn(sbService, 'share').and.callThrough(); // spy on ShareButtonsService.share()
-
-
-      shareButton.triggerEventHandler('click', null); // simulate click on button
-
-      expect(shareSpy).toHaveBeenCalledWith(sBtn.provider, sArgs, component.popUpClosed);
-      expect(emittedProvider).toEqual(sBtn.provider);
-
-      expect(windowService.nativeWindow.open.calls.count()).toBe(1);
-      expect(windowService.nativeWindow.open.calls.mostRecent().args).toEqual([shareUrl, 'newwindow', sbService.windowAttr()]);
-      expect(windowService.nativeWindow.setInterval.calls.count()).toBe(1);
-      expect(windowService.nativeWindow.clearInterval.calls.count()).toBe(1); // make sure timeout handler has been cleared
-    }));
-
-
-  it('should render the share count and emit "countOuter" event if @Input("count") is true and shareCount > 0',
-    inject([ShareButtonsService], (sbService: ShareButtonsService) => {
-
-      // set mandatory inputs
-      component.button = sBtn;
-
-      // optional inputs
-      component.url = sArgs.url;
-      component.title = sArgs.title;
-      component.description = sArgs.description;
-      component.image = sArgs.image;
-      component.tags = sArgs.tags;
-
-      component.count = true;
-
-      let emittedTotalCount: number;
-      component.countOuter.subscribe((count: number) => {
-        emittedTotalCount = count;
-      });
-
-      const shareCount = 1999;
-      const countSpy = spyOn(sbService, 'count').and.callFake(// spy on ShareButtonsService.count()
-
-        (provider: ShareProvider, url: String) => Observable.of(shareCount)
-      );
-
-      fixture.detectChanges(); // trigger data binding
-
-      expect(countSpy).toHaveBeenCalledWith(sBtn.provider, sArgs.url);
-      expect(emittedTotalCount).toEqual(shareCount);
-
-      const spanCount = fixture.debugElement.query(By.css('span')).nativeElement;
-      expect(spanCount.className).toEqual('sb-button-count');
-      expect(spanCount.textContent).toEqual('2K'); // count formatted with NFormatterPipe
-
-    }));
-
-
-  it('should not render the share count, not emit "countOuter" event if @Input("count") is true but shareCount <= 0',
-    inject([ShareButtonsService], (sbService: ShareButtonsService) => {
-
-      // set mandatory inputs
-      component.button = sBtn;
-
-      // optional inputs
-      component.url = sArgs.url;
-      component.title = sArgs.title;
-      component.description = sArgs.description;
-      component.image = sArgs.image;
-      component.tags = sArgs.tags;
-
-      component.count = true;
-
-      let emittedTotalCount: number;
-      component.countOuter.subscribe((count: number) => {
-        emittedTotalCount = count;
-      });
-
-      const shareCount = 0;
-      const countSpy = spyOn(sbService, 'count').and.callFake(// spy on ShareButtonsService.count()
-
-        (provider: ShareProvider, url: String) => Observable.of(shareCount)
-      );
-
-      fixture.detectChanges(); // trigger data binding
-
-      expect(countSpy).toHaveBeenCalledWith(sBtn.provider, sArgs.url);
-      expect(emittedTotalCount).toBeUndefined();
-      expect(fixture.debugElement.query(By.css('span'))).toBeNull();
-    }));
 
 });
 
 describe('ShareButtonComponent (as used by hosting component)', () => {
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ShareButtonsModule],
-      declarations: [TestComponent]
-    }).compileComponents();
-  }));
+      imports: [ShareButtonsModule, HttpModule, JsonpModule],
+      declarations: [TestComponent],
+      providers: [
+        { provide: WindowService, useClass: TestHelpers.MockWindowService }
+      ]
+    });
+  });
 
   it('should throw error if mandatory @Input("button") is not set', () => {
     const fixture = createTestComponent(`
@@ -227,23 +87,184 @@ describe('ShareButtonComponent (as used by hosting component)', () => {
     expect(fixture.detectChanges).toThrowError();
   });
 
-  /**  TODO: find why this still fails
-    it('should bind to parameters provided by hosting component', () => {
-      const fixture = createTestComponent(`
+  it('should bind to parameters provided by hosting component', () => {
+    const fixture = createTestComponent(`
          <share-button [button]="sBtn" 
            [url]="sArgs.url" 
            [title]="sArgs.title" 
            [description]="sArgs.description" 
            [image]="sArgs.image" 
-           [tags]="sArgs.tags">
+           [tags]="sArgs.tags"
+           [count]="true"
+           (countOuter) = "countCallback($event)"
+           (popUpClosed) = "popUpCallback($event)">
          </share-button>
-       `, true);
-  
-      const sbButton = fixture.debugElement.query(By.css('share-button'));
-  
-      expect(sbButton).toBeTruthy();
+       `, true /* detectChanges */);
+
+    const component = fixture.componentInstance;
+    const sbButton = fixture.debugElement.query(By.css('share-button'));
+
+    expect(sbButton).toBeTruthy();
+    const sbComponent = sbButton.componentInstance as ShareButtonComponent;
+
+    const lnButton = sbButton.query(By.css('button'));
+    expect(lnButton).toBeTruthy();
+    expect(lnButton.nativeElement.className).toEqual(component.sBtn.classes);
+    expect(lnButton.nativeElement.innerHTML).toEqual(component.sBtn.template);
+
+    const countSpan = sbButton.query(By.css('.share-button-count'));
+    if (sbComponent.shareCount) {
+      expect(countSpan).toBeTruthy(); // 'count' is true, 'shareCount' = 0
+    } else {
+      expect(countSpan).toBeFalsy(); // 'count' is true, 'shareCount' = 0
+    }
+
+  });
+
+
+  it('should use "window.location.href" when no url is provided', () => {
+    const fixture = createTestComponent(`
+         <share-button [button]="sBtn"> 
+         </share-button>
+       `, true /* detectChanges */);
+
+    const sbComponent = getShareButtonComponent(fixture);
+    expect(sbComponent.url).toEqual(encodeURIComponent(TestHelpers.windowUrl));
+
+  });
+
+  it('should use "window.location.href" when provided url is invalid', () => {
+
+    const fixture = createTestComponent(`
+         <share-button [button]="sBtn"> 
+          [url]="invalid://www.mysite.com"
+         </share-button>
+       `, true /* detectChanges */);
+
+    const sbComponent = getShareButtonComponent(fixture);
+    expect(sbComponent.url).toEqual(encodeURIComponent(TestHelpers.windowUrl));
+
+  });
+
+  it('should call share() when the button is clicked and emit "popUpClosed" event', () => {
+
+    const fixture = createTestComponent(`
+         <share-button [button]="sBtn" 
+           [url]="sArgs.url" 
+           [title]="sArgs.title" 
+           [description]="sArgs.description" 
+           [image]="sArgs.image" 
+           [tags]="sArgs.tags"
+           (popUpClosed) = "popUpCallback($event)">
+         </share-button>
+       `);
+
+    const sbService = TestBed.get(ShareButtonsService);
+    const shareSpy = spyOn(sbService, 'share').and.callThrough(); // spy on ShareButtonsService.share()
+    const windowService = TestBed.get(WindowService);
+
+    const testComponent = fixture.componentInstance;
+    const sbComponent = getShareButtonComponent(fixture);
+    const shareButton = getShareButtonDebugElm(fixture).query(By.css('button'));
+    const shareUrl = Helper.shareFactory(sBtn.provider, sArgs);
+
+
+    let emittedProvider: ShareProvider;
+    sbComponent.popUpClosed.subscribe((provider: ShareProvider) => {
+      emittedProvider = provider;
     });
-  */
+
+
+    fixture.detectChanges(); // trigger data binding
+
+    shareButton.triggerEventHandler('click', null); // simulate click on button
+
+    expect(shareSpy).toHaveBeenCalledWith(sBtn.provider, sArgs, sbComponent.popUpClosed);
+    expect(emittedProvider).toEqual(sBtn.provider);
+
+    expect(windowService.nativeWindow.open.calls.count()).toBe(1);
+    expect(windowService.nativeWindow.open.calls.mostRecent().args).toEqual([shareUrl, 'newwindow', sbService.windowAttr()]);
+    expect(windowService.nativeWindow.setInterval.calls.count()).toBe(1);
+    expect(windowService.nativeWindow.clearInterval.calls.count()).toBe(1); // make sure timeout handler has been cleared
+
+    expect(testComponent.popUpCallback).toHaveBeenCalledWith(testComponent.sBtn.provider);
+  });
+
+
+  it('should render the share count and emit "countOuter" event if @Input("count") is true and shareCount > 0', () => {
+
+    const fixture = createTestComponent(`
+         <share-button [button]="sBtn" 
+           [url]="sArgs.url" 
+           [title]="sArgs.title" 
+           [description]="sArgs.description" 
+           [image]="sArgs.image" 
+           [tags]="sArgs.tags"
+           [count]="true"
+           (countOuter) = "countCallback($event)">
+         </share-button>
+       `);
+
+    const sbService = TestBed.get(ShareButtonsService);
+    const sbComponent = getShareButtonComponent(fixture);
+
+    let emittedShareCount: number;
+    sbComponent.countOuter.subscribe((count: number) => {
+      emittedShareCount = count;
+    });
+
+    const shareCount = 1999;
+    const countSpy = spyOn(sbService, 'count').and.callFake(// spy on ShareButtonsService.count()
+      (provider: ShareProvider, url: String) => Observable.of(shareCount)
+    );
+
+    fixture.detectChanges(); // trigger data binding
+
+    expect(countSpy).toHaveBeenCalledWith(sBtn.provider, sArgs.url);
+    expect(emittedShareCount).toEqual(shareCount);
+
+    const countSpan = getShareButtonDebugElm(fixture).query(By.css('span')).nativeElement;
+    expect(countSpan.className).toEqual('sb-button-count');
+    expect(countSpan.textContent).toEqual('2K'); // count formatted with NFormatterPipe
+
+  });
+
+
+  it('should not render the share count, not emit "countOuter" event if @Input("count") is true but shareCount <= 0', () => {
+
+    const fixture = createTestComponent(`
+         <share-button [button]="sBtn" 
+           [url]="sArgs.url" 
+           [title]="sArgs.title" 
+           [description]="sArgs.description" 
+           [image]="sArgs.image" 
+           [tags]="sArgs.tags"
+           [count]="true"
+           (countOuter) = "countCallback($event)">
+         </share-button>
+       `);
+
+    const sbService = TestBed.get(ShareButtonsService);
+    const component = fixture.componentInstance;
+    const sbComponent = getShareButtonComponent(fixture);
+
+    let emittedShareCount: number;
+    sbComponent.countOuter.subscribe((count: number) => {
+      emittedShareCount = count;
+    });
+
+    const shareCount = 0;
+    const countSpy = spyOn(sbService, 'count').and.callFake(// spy on ShareButtonsService.count()
+      (provider: ShareProvider, url: String) => Observable.of(shareCount)
+    );
+
+    fixture.detectChanges(); // trigger data binding
+
+    expect(countSpy).toHaveBeenCalledWith(sBtn.provider, sArgs.url);
+    expect(emittedShareCount).toEqual(shareCount);
+    expect(getShareButtonDebugElm(fixture).query(By.css('span'))).toBeNull();
+  });
+
 });
 
 
@@ -252,4 +273,7 @@ class TestComponent {
 
   sArgs = new ShareArgs('http://www.mysite.com', 'my title', 'my description', 'https://my/image.png', 'tag1,tag2');
   sBtn = new ShareButton(ShareProvider.LINKEDIN, '<i class="fa fa-linkedin"></i>', 'linkedin');
+
+  countCallback = jasmine.createSpy('countCallback').and.callFake((count: number) => { });
+  popUpCallback = jasmine.createSpy('popUpCallback').and.callFake((provider: ShareProvider) => { });
 }


### PR DESCRIPTION
- replace DOM manipulation by a "template" approach
- replace `ngOnInit` by `ngOnChanges`. Closes #34
- remove ElementRef, Renderer classes
- add an external template file
- fix and complete component tests