### PR TITLE
Call `index` files explicitly to keep AoT from failing

### DIFF
--- a/src/components/share-button/share-button.component.spec.ts
+++ b/src/components/share-button/share-button.component.spec.ts
@@ -11,7 +11,7 @@ import { ShareButtonDirective } from './../../directives/share-button/share-butt
 import { ShareButtonComponent } from './share-button.component';
 import { ShareButtonsService } from '../../services/share-buttons.service';
 import { WindowService } from './../../services/window.service';
-import { ShareButton, ShareArgs, ShareProvider, Helper, NFormatterPipe } from '../../helpers';
+import { ShareButton, ShareArgs, ShareProvider, Helper, NFormatterPipe } from '../../helpers/index';
 import { TestHelpers } from '../../test-helpers';
 
 
@@ -91,11 +91,11 @@ describe('ShareButtonComponent (as used by hosting component)', () => {
 
   it('should bind to parameters provided by hosting component', () => {
     const fixture = createTestComponent(`
-         <share-button [button]="sBtn" 
-           [url]="sArgs.url" 
-           [title]="sArgs.title" 
-           [description]="sArgs.description" 
-           [image]="sArgs.image" 
+         <share-button [button]="sBtn"
+           [url]="sArgs.url"
+           [title]="sArgs.title"
+           [description]="sArgs.description"
+           [image]="sArgs.image"
            [tags]="sArgs.tags"
            [showCount]="true"
            (countOuter) = "countCallback($event)"
@@ -130,11 +130,11 @@ describe('ShareButtonComponent (as used by hosting component)', () => {
   it('should call share() when the button is clicked and emit "popUpClosed" event', () => {
 
     const fixture = createTestComponent(`
-         <share-button [button]="sBtn" 
-           [url]="sArgs.url" 
-           [title]="sArgs.title" 
-           [description]="sArgs.description" 
-           [image]="sArgs.image" 
+         <share-button [button]="sBtn"
+           [url]="sArgs.url"
+           [title]="sArgs.title"
+           [description]="sArgs.description"
+           [image]="sArgs.image"
            [tags]="sArgs.tags"
            (popUpClosed) = "popUpCallback($event)">
          </share-button>
@@ -175,11 +175,11 @@ describe('ShareButtonComponent (as used by hosting component)', () => {
   it('should render the share count and emit "countOuter" event if @Input("showCount") is true and shareCount > 0', () => {
 
     const fixture = createTestComponent(`
-         <share-button [button]="sBtn" 
-           [url]="sArgs.url" 
-           [title]="sArgs.title" 
-           [description]="sArgs.description" 
-           [image]="sArgs.image" 
+         <share-button [button]="sBtn"
+           [url]="sArgs.url"
+           [title]="sArgs.title"
+           [description]="sArgs.description"
+           [image]="sArgs.image"
            [tags]="sArgs.tags"
            [showCount]="true"
            (countOuter) = "countCallback($event)">
@@ -217,11 +217,11 @@ describe('ShareButtonComponent (as used by hosting component)', () => {
   it('should not render the share count, not emit "countOuter" event if @Input("showCount") is true but shareCount <= 0', () => {
 
     const fixture = createTestComponent(`
-         <share-button [button]="sBtn" 
-           [url]="sArgs.url" 
-           [title]="sArgs.title" 
-           [description]="sArgs.description" 
-           [image]="sArgs.image" 
+         <share-button [button]="sBtn"
+           [url]="sArgs.url"
+           [title]="sArgs.title"
+           [description]="sArgs.description"
+           [image]="sArgs.image"
            [tags]="sArgs.tags"
            [showCount]="true"
            (countOuter) = "countCallback($event)">

--- a/src/components/share-button/share-button.component.ts
+++ b/src/components/share-button/share-button.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
-import { ShareButton, ShareProvider } from '../../helpers';
+import { ShareButton, ShareProvider } from '../../helpers/index';
 
 @Component({
     selector: 'share-button',

--- a/src/components/share-buttons/share-buttons.component.spec.ts
+++ b/src/components/share-buttons/share-buttons.component.spec.ts
@@ -11,7 +11,7 @@ import { ShareButtonDirective } from './../../directives/share-button/share-butt
 import { NFormatterPipe } from '../../helpers/n-formatter.pipe';
 import { ShareButtonsService } from '../../services/share-buttons.service';
 import { WindowService } from '../../services/window.service';
-import { ShareButton, ShareArgs, ShareProvider, Helper } from '../../helpers';
+import { ShareButton, ShareArgs, ShareProvider, Helper } from '../../helpers/index';
 
 import { TestHelpers } from '../../test-helpers';
 
@@ -131,7 +131,7 @@ describe('ShareButtonsComponent (as a stand-alone component)', () => {
         const twButton = sbButtons.query(By.css('.twitter'));
         expect(twButton).toBeTruthy();
         expect(twButton.nativeElement.className).toEqual('sb-button twitter');
-        
+
         const twTemplate = twButton.query(By.css('.sb-template'));
         expect(twTemplate.nativeElement.innerHTML).toEqual('<i class="fa fa-twitter"></i>');
         // make sure that @Input of inner share-button have been properly bound
@@ -484,11 +484,11 @@ describe('ShareButtonComponent (as used by hosting component)', () => {
     it('should call "popUpClosed" with the provider referring to the button that was clicked', () => {
 
         const fixture = createTestComponent(`
-         <share-buttons 
-           [url]="sArgs.url" 
-           [title]="sArgs.title" 
-           [description]="sArgs.description" 
-           [image]="sArgs.image" 
+         <share-buttons
+           [url]="sArgs.url"
+           [title]="sArgs.title"
+           [description]="sArgs.description"
+           [image]="sArgs.image"
            [tags]="sArgs.tags"
            (popUpClosed) = "popUpCallback($event)">
          </share-buttons>

--- a/src/components/share-buttons/share-buttons.component.ts
+++ b/src/components/share-buttons/share-buttons.component.ts
@@ -9,7 +9,7 @@ import {
     EventEmitter,
     SimpleChanges,
 } from '@angular/core';
-import { ShareButton, ShareProvider } from '../../helpers';
+import { ShareButton, ShareProvider } from '../../helpers/index';
 
 @Component({
     selector: 'share-buttons',

--- a/src/directives/share-button/share-button.directive.spec.ts
+++ b/src/directives/share-button/share-button.directive.spec.ts
@@ -3,14 +3,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Component, EventEmitter } from '@angular/core';
 import { HttpModule, JsonpModule } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
 
 import { ShareButtonsModule } from '../../share-buttons.module';
 import { ShareButtonDirective } from './share-button.directive';
 import { ShareButtonsService } from '../../services/share-buttons.service';
 import { WindowService } from '../../services/window.service';
-import { ShareButton, ShareArgs, ShareProvider, Helper } from '../../helpers';
+import { ShareButton, ShareArgs, ShareProvider, Helper } from '../../helpers/index';
 import { TestHelpers } from '../../test-helpers';
 
 const createTestComponent = (html: string, detectChanges?: boolean) =>
@@ -30,7 +28,7 @@ describe('ShareButtonDirective', () => {
             ]
         });
     });
-    
+
     it('should throw error if mandatory @Input("shareButton") is not set', () => {
         expect(() =>
             createTestComponent(`<button shareButton></button>`, true)

--- a/src/directives/share-button/share-button.directive.ts
+++ b/src/directives/share-button/share-button.directive.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 
 import { ShareButtonsService } from '../../services/share-buttons.service';
-import { ShareArgs, ShareProvider, Helper } from '../../helpers';
+import { ShareArgs, ShareProvider, Helper } from '../../helpers/index';
 
 @Directive({
     selector: '[shareButton]'

--- a/src/helpers/n-formatter.pipe.spec.ts
+++ b/src/helpers/n-formatter.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { NFormatterPipe } from '.';
+import { NFormatterPipe } from './index';
 
 describe('NFormatterPipe, Isolated Test', () => {
 

--- a/src/helpers/n-formatter.pipe.ts
+++ b/src/helpers/n-formatter.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Helper } from '.';
+import { Helper } from './index';
 
 @Pipe({
     name: 'nFormatter'

--- a/src/helpers/share-buttons.class.spec.ts
+++ b/src/helpers/share-buttons.class.spec.ts
@@ -1,4 +1,4 @@
-import { ShareProvider, ShareButton, ShareArgs } from '.';
+import { ShareProvider, ShareButton, ShareArgs } from './index';
 
 describe('ShareButton', () => {
     it('should create an instance with given values', () => {

--- a/src/helpers/share-links.functions.spec.ts
+++ b/src/helpers/share-links.functions.spec.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-line-length */
 
-import { ShareArgs, ShareLinks } from '.';
+import { ShareArgs, ShareLinks } from './index';
 
 
 describe('Module: ShareLinks, Isolated Tests', () => {

--- a/src/helpers/share.helper.spec.ts
+++ b/src/helpers/share.helper.spec.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-line-length */
 
-import { ShareProvider, ShareArgs, Helper } from '.';
+import { ShareProvider, ShareArgs, Helper } from './index';
 
 
 

--- a/src/services/share-buttons.service.spec.ts
+++ b/src/services/share-buttons.service.spec.ts
@@ -6,7 +6,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { MockBackend } from '@angular/http/testing';
 
 import { ShareButtonsService } from './share-buttons.service';
-import { ShareProvider, ShareArgs, Helper } from '../helpers';
+import { ShareProvider, ShareArgs, Helper } from '../helpers/index';
 import { WindowService } from './window.service';
 import { TestHelpers } from '../test-helpers';
 

--- a/src/services/share-buttons.service.ts
+++ b/src/services/share-buttons.service.ts
@@ -5,7 +5,7 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/empty';
 
 import { WindowService } from './window.service';
-import { ShareArgs, ShareProvider, Helper } from '../helpers';
+import { ShareArgs, ShareProvider, Helper } from '../helpers/index';
 
 declare const global: any; // To make AoT compiler (ngc) happy
 

--- a/src/share-buttons.module.ts
+++ b/src/share-buttons.module.ts
@@ -8,7 +8,7 @@ import { ShareButtonDirective } from './directives/share-button/share-button.dir
 import { ShareButtonsService } from './services/share-buttons.service';
 import { WindowService } from './services/window.service';
 import { NFormatterPipe } from './helpers/n-formatter.pipe';
-import { ShareButton, ShareArgs, ShareProvider } from './helpers';
+import { ShareButton, ShareArgs, ShareProvider } from './helpers/index';
 
 @NgModule({
   declarations: [


### PR DESCRIPTION
When the AoT builder tries to build the files, it will try to call `helpers.js` instead of `helpers/index.js`.
To fix this, explicitly call the correct file.