### PR TITLE
chore(build): Expanding wildcard export on the index barrel to allow …

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,19 @@
-export * from './share-buttons.module';
+import { ShareButtonsComponent } from './components/share-buttons/share-buttons.component';
+import { ShareButtonComponent } from './components/share-button/share-button.component';
+import { ShareButtonDirective } from './directives/share-button/share-button.directive';
+import { ShareButtonsService } from './services/share-buttons.service';
+import { NFormatterPipe } from './helpers/n-formatter.pipe';
+import { ShareButton, ShareArgs, ShareProvider } from './helpers/index';
+import { ShareButtonsModule } from './share-buttons.module';
+
+export {
+    ShareButtonsModule,
+    ShareButtonsComponent,
+    ShareButtonComponent,
+    ShareButtonDirective,
+    ShareButton,
+    NFormatterPipe,
+    ShareButtonsService,
+    ShareArgs,
+    ShareProvider
+}


### PR DESCRIPTION
…ng2-sharebuttons to be used with closure compiler in advanced mode.

This will be more and more of an issue when angular 4 comes out, given that the use of closure compiler in advanced mode will be more common now. 

This is a temporary change, once this gets implemented (which is should very soon):

https://github.com/google/closure-compiler/issues/878

...then we can go back to the wildcard export, which is nice for barrels.